### PR TITLE
Parallelize map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 
 temp/*
 .markdownlin*
+*.bedGraph
+*.bigWig
+*.bw

--- a/README.md
+++ b/README.md
@@ -28,17 +28,16 @@ conda activate articull-env
 
 ### 2. Setting up Genomic Data Tracks
 
-Use the provided script to download and process the reference genome mappability track:
+Use the provided script to download and process the reference genome mappability track. Note that the download requires ~1GB of space and expands to ~5GB when uncompressed.
+By default, files are saved to the `resources` directory unless an alternative output directory is specified.
 
 ```bash
 bash scripts/setup_mappability_track.bash [optional: output_directory]
 ```
 
-**Note**: 
-- By default, files are saved to the `resources` directory unless an alternative output directory is specified
-- The download requires ~1GB of space and expands to ~5GB when uncompressed
-- Currently only `hg19`/`GRCh37` is supported. Support for additional reference genomes coming soon
-- For other genome versions, please open an issue on [GitHub](https://github.com/shahcompbio/ArtiCull/issues)
+Currently only `hg19`/`GRCh37` is supported. Support for additional reference genomes coming soon. For other genome versions, please open an issue on [GitHub](https://github.com/shahcompbio/ArtiCull/issues).
+
+
 
 ## Example Usage
 
@@ -70,21 +69,21 @@ conda activate articull-env
 
 ```bash
 maf=example/example.maf
-features_output=example/articull.features.tsv
+extract_features_output=example/articull.features.tsv
 bam=example/example.bam
-mappability_file=resources/hg19_mappability.bedGraph  # update if you saved to a different location during setup
+resources_dir=resources/  # update if you saved to a different location during setup
 
-python src/main.py extract_features $maf $features_output $bam --map_bedgraph $mappability_file --cores 8 
+python src/main.py extract_features $maf $extract_features_output $bam --resources_dir $resources_dir --cores 8 
 ```
 
 ### 2. Run classification
 
 ```bash
-features=example/articull.features.tsv
+extract_features_output=example/articull.features.tsv
 output_dir=example/
 model_dir=models/preprint_model/
 
-python src/main.py classify $features $output_dir $model_dir
+python src/main.py classify $extract_features_output $output_dir $model_dir
 ```
 
 ### Output
@@ -124,7 +123,7 @@ The `extract_features` command processes input variants and generates features r
 #### Usage
 
 ```bash
-python src/main.py extract_features <input_file> <output> <bams> [--map_bedgraph <bedgraph>] [--cores <ncores>]
+python src/main.py extract_features <input_file> <output> <bams> [--resources_dir <path>] [--cores <ncores>]
 ```
 
 #### Arguments
@@ -134,7 +133,7 @@ python src/main.py extract_features <input_file> <output> <bams> [--map_bedgraph
 | `<input_file>` | Yes | Candidate variants file (MAF or VCF format) |
 | `<output>` | Yes | Output path for extracted features (tab-separated format) |
 | `<bams>` | Yes | One or more BAM files containing sequencing data |
-| `--map_bedgraph` | No | Path to mappability bedgraph file (default: `resources/hg19_mappability.bedGraph`) |
+| `--resources_dir` | No | Path to directory containing folder `mappability`  with downloaded mappability tracks [See [Setup](#setup)] (default: `resources/hg19_mappability.bedGraph`) |
 | `--cores` | No | Number of CPU cores for parallel processing |
 
 ### Running Classification

--- a/scripts/setup_mappability_track.bash
+++ b/scripts/setup_mappability_track.bash
@@ -31,6 +31,9 @@ curl -O "$URL" || { echo "Download failed!"; exit 1; }
 echo "Converting to BedGraph. This may take a few minutes..."
 bigWigToBedGraph "$FILE" "${GENOME}_mappability.bedGraph" || { echo "Conversion failed!"; exit 1; }
 
+# Delete original file
+echo "Cleaning up $FILE..."
+rm "$FILE"
 
 
 # Create mappability directory
@@ -40,9 +43,8 @@ mkdir -p "$OUTPUT_DIR/mappability"
 echo "Splitting BedGraph into individual chromosome files..."
 awk '{print > ("'"$OUTPUT_DIR/mappability/"'" $1 ".bedGraph")}' "${GENOME}_mappability.bedGraph" || { echo "Splitting failed!"; exit 1; }
 
-# Delete original file
-echo "Cleaning up..."
-rm "$FILE"
+# Delete full BedGraph file
+echo "Cleaning up ${GENOME}_mappability.bedGraph..."
 rm "${GENOME}_mappability.bedGraph"
 
 echo "Setup complete! Processed files saved to: $OUTPUT_DIR/mappability/*.bedGraph"

--- a/scripts/setup_mappability_track.bash
+++ b/scripts/setup_mappability_track.bash
@@ -31,8 +31,18 @@ curl -O "$URL" || { echo "Download failed!"; exit 1; }
 echo "Converting to BedGraph. This may take a few minutes..."
 bigWigToBedGraph "$FILE" "${GENOME}_mappability.bedGraph" || { echo "Conversion failed!"; exit 1; }
 
+
+
+# Create mappability directory
+mkdir -p "$OUTPUT_DIR/mappability"
+
+# Split BedGraph into individual chromosome files
+echo "Splitting BedGraph into individual chromosome files..."
+awk '{print > ("'"$OUTPUT_DIR/mappability/"'" $1 ".bedGraph")}' "${GENOME}_mappability.bedGraph" || { echo "Splitting failed!"; exit 1; }
+
 # Delete original file
 echo "Cleaning up..."
 rm "$FILE"
+rm "${GENOME}_mappability.bedGraph"
 
-echo "Setup complete! Processed file saved to: $OUTPUT_DIR/${GENOME}_mappability.bedGraph"
+echo "Setup complete! Processed files saved to: $OUTPUT_DIR/mappability/*.bedGraph"

--- a/src/extract_features.py
+++ b/src/extract_features.py
@@ -17,6 +17,7 @@ def main(args):
     validate_arguments(args)
     random.seed(42)
     maf, bams, mappability, output = args.input_file, args.bams, args.map_bedgraph, args.output
+    mappability = os.path.join(mappability, 'mappability') # 
     
     #cell_labels = None if cell_labels.lower() == 'none' else cell_labels
 
@@ -48,8 +49,8 @@ def add_parser_arguments(parser):
 
     script_dir = os.path.dirname(os.path.abspath(__file__))
     repo_root = os.path.abspath(os.path.join(script_dir, os.pardir))
-    default_resources_path = os.path.join(repo_root, 'resources', 'hg19_mappability.bedGraph')
-    parser.add_argument('--map_bedgraph', type=str, default=default_resources_path, help='<Optional> Mappability bedgraph (default: resources/hg19_mappability.bedGraph)')
+    default_resources_path = os.path.join(repo_root, 'resources')
+    parser.add_argument('--resources_dir', type=str, default=default_resources_path, help='<Optional> Path to directory containing folder of mappability tracks (default: {}'.format(default_resources_path))
 
 def validate_arguments(args):
     # Checks if input files exist and if output files are in directories that exist and can be written to


### PR DESCRIPTION
Mappability took a long time in extract_features since we were intersecting with a large bedgraph. This pull request updates the setup of mappability files (`scripts/setup_mappability_track.bash` to divide them into individual chromosomes. 
src/extract_features.py was updated to use these split mappability tracks, and to implement parallelization for the processing. README.md updated to match. 